### PR TITLE
Fix memory leaks in cleanup by disposing child meshes recursively

### DIFF
--- a/src/stages/Stage3.js
+++ b/src/stages/Stage3.js
@@ -109,14 +109,18 @@ export function Stage3() {
 
       objects.forEach((obj) => {
         scene.remove(obj);
-        if (obj.geometry) obj.geometry.dispose();
-        if (obj.material) {
-          if (Array.isArray(obj.material)) {
-            obj.material.forEach((m) => m.dispose());
-          } else {
-            obj.material.dispose();
+        obj.traverse((child) => {
+          if (child.isMesh) {
+            if (child.geometry) child.geometry.dispose();
+            if (child.material) {
+              if (Array.isArray(child.material)) {
+                child.material.forEach((m) => m.dispose());
+              } else {
+                child.material.dispose();
+              }
+            }
           }
-        }
+        });
       });
       objects.length = 0;
       scene.background = null;

--- a/src/stages/Stage4.js
+++ b/src/stages/Stage4.js
@@ -109,14 +109,18 @@ export function Stage4() {
 
       objects.forEach((obj) => {
         scene.remove(obj);
-        if (obj.geometry) obj.geometry.dispose();
-        if (obj.material) {
-          if (Array.isArray(obj.material)) {
-            obj.material.forEach((m) => m.dispose());
-          } else {
-            obj.material.dispose();
+        obj.traverse((child) => {
+          if (child.isMesh) {
+            if (child.geometry) child.geometry.dispose();
+            if (child.material) {
+              if (Array.isArray(child.material)) {
+                child.material.forEach((m) => m.dispose());
+              } else {
+                child.material.dispose();
+              }
+            }
           }
-        }
+        });
       });
       objects.length = 0;
       scene.background = null;

--- a/src/stages/Stage5.js
+++ b/src/stages/Stage5.js
@@ -42,14 +42,18 @@ export function Stage5() {
     cleanup(scene) {
       objects.forEach((obj) => {
         scene.remove(obj);
-        if (obj.geometry) obj.geometry.dispose();
-        if (obj.material) {
-          if (Array.isArray(obj.material)) {
-            obj.material.forEach((m) => m.dispose());
-          } else {
-            obj.material.dispose();
+        obj.traverse((child) => {
+          if (child.isMesh) {
+            if (child.geometry) child.geometry.dispose();
+            if (child.material) {
+              if (Array.isArray(child.material)) {
+                child.material.forEach((m) => m.dispose());
+              } else {
+                child.material.dispose();
+              }
+            }
           }
-        }
+        });
       });
       objects.length = 0;
       scene.background = null;

--- a/src/stages/Stage6.js
+++ b/src/stages/Stage6.js
@@ -42,14 +42,18 @@ export function Stage6() {
     cleanup(scene) {
       objects.forEach((obj) => {
         scene.remove(obj);
-        if (obj.geometry) obj.geometry.dispose();
-        if (obj.material) {
-          if (Array.isArray(obj.material)) {
-            obj.material.forEach((m) => m.dispose());
-          } else {
-            obj.material.dispose();
+        obj.traverse((child) => {
+          if (child.isMesh) {
+            if (child.geometry) child.geometry.dispose();
+            if (child.material) {
+              if (Array.isArray(child.material)) {
+                child.material.forEach((m) => m.dispose());
+              } else {
+                child.material.dispose();
+              }
+            }
           }
-        }
+        });
       });
       objects.length = 0;
       scene.background = null;


### PR DESCRIPTION
## 특이사항
- 기존 cleanup 로직에서 객체의 직접 geometry/material만 dispose하고 있었으나, Three.js 객체가 자식 메시 구조를 가질 수 있어 메모리 누수 발생
- `traverse()` 메서드를 사용하여 객체 계층 구조의 모든 자식 메시를 순회하며 리소스 정리
- Stage3, Stage4, Stage5, Stage6의 cleanup 함수에 동일한 패턴 적용

## 변경사항
- 모든 Stage의 cleanup 함수에서 단순 객체 dispose에서 재귀적 자식 메시 dispose로 변경
- `obj.traverse((child) => { if (child.isMesh) { ... } })` 패턴으로 통일
- 이를 통해 복합 객체 구조에서도 모든 geometry와 material이 제대로 정리됨

https://claude.ai/code/session_01FqhM2Gz615Vq3RqKpic6fX